### PR TITLE
Fix configs for API URL

### DIFF
--- a/client/duneapi/client.go
+++ b/client/duneapi/client.go
@@ -120,7 +120,8 @@ func (c *client) sendRequest(request BlockchainIngestRequest) error {
 		}
 	}()
 
-	url := fmt.Sprintf("%s/beta/blockchain/%s/chain", c.cfg.URL, c.cfg.BlockchainName)
+	url := fmt.Sprintf("%s/beta/blockchain/%s/ingest", c.cfg.URL, c.cfg.BlockchainName)
+	c.log.Debug("Sending request", "url", url)
 	req, err := retryablehttp.NewRequest("POST", url, bytes.NewReader(request.Payload))
 	if err != nil {
 		return err

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,7 @@ import (
 
 type DuneClient struct {
 	APIKey string `long:"dune-api-key" env:"DUNE_API_KEY" description:"API key for DuneAPI"`
-	URL    string `long:"dune-api-url" env:"DUNE_API_URL" description:"URL for DuneAPI" default:"https://api.dune.com/"`
+	URL    string `long:"dune-api-url" env:"DUNE_API_URL" description:"URL for DuneAPI" default:"https://api.dune.com/api"`
 }
 
 func (d DuneClient) HasError() error {


### PR DESCRIPTION
This now works out of the box with

```
go run cmd/main.go --blockchain-name byob --dune-api-url "https://api.dev.dune.com/api" --rpc-node-url "https://sepolia.rpc.zora.energy"
```

(assuming I have the `DUNE_API_KEY` env var set to a dune team api key in dev)